### PR TITLE
fix(p_ast): honour expected_value in AstConstant.update_leafs_mop

### DIFF
--- a/src/d810/expr/p_ast.py
+++ b/src/d810/expr/p_ast.py
@@ -1197,6 +1197,15 @@ class AstConstant(AstLeaf):
             source_leaf = other2.leafs_by_name[self.name]
 
         if source_leaf is None:
+            # Literal AstConstant: value is already known via expected_value
+            # (e.g. Const("ONE", 1), NEGATIVE_TWO, ZERO defined in d810.mba.dsl)
+            # and no candidate binding is required. Downstream
+            # _materialize_replacement_constants will synthesize a mop_t from
+            # expected_value. Without this guard, REPLACEMENTs that reference a
+            # numeric constant not present in PATTERN silently fail to fire
+            # (e.g. Mul_FactorRule_2 with `NEG_TWO * (x & y)`).
+            if self.expected_value is not None:
+                return True
             return False
 
         # Copy mop if available

--- a/tests/system/runtime/expr/test_ast_update_leafs_mop.py
+++ b/tests/system/runtime/expr/test_ast_update_leafs_mop.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import unittest
+
 from d810.expr import p_ast
 
 
@@ -52,3 +54,48 @@ def test_update_leafs_mop_delegates_to_leaf_specific_update():
     assert failing_leaf.calls == 1
     assert ok_leaf.mop == "mop_x"
     assert failing_leaf.mop == "mop_c"
+
+
+class _EmptyCandidate:
+    """Stand-in for an AstNode candidate whose leafs_by_name has nothing for
+    the constant being queried. Mirrors what happens for REPLACEMENT-side
+    literal constants (e.g. NEGATIVE_TWO from d810.mba.dsl) that have no
+    binding in the matched pattern."""
+
+    def __init__(self):
+        self.leafs_by_name = {}
+
+
+class TestAstConstantUpdateLeafsMop(unittest.TestCase):
+    """Regression tests for AstConstant.update_leafs_mop literal-value handling.
+
+    Guards against the bug where a REPLACEMENT referencing a numeric constant
+    not bound in PATTERN (e.g. Mul_FactorRule_2's ``NEG_TWO * (x & y)``)
+    silently fails to fire because update_leafs_mop returned False whenever
+    the constant's name was missing from the candidate's leafs_by_name —
+    even when expected_value was already set at construction time. This
+    aborted get_replacement before _materialize_replacement_constants could
+    synthesise the constant mop_t from expected_value.
+    """
+
+    def test_with_expected_value_short_circuits(self):
+        """Literal constant with expected_value succeeds without binding."""
+        const = p_ast.AstConstant("NEG_TWO", expected_value=-2)
+        self.assertTrue(const.update_leafs_mop(_EmptyCandidate()))
+
+    def test_zero_value_short_circuits(self):
+        """expected_value=0 is a real value, not a missing binding."""
+        const = p_ast.AstConstant("ZERO", expected_value=0)
+        self.assertTrue(const.update_leafs_mop(_EmptyCandidate()))
+
+    def test_without_expected_value_returns_false(self):
+        """Pattern-bound constants with no expected_value still return False."""
+        const = p_ast.AstConstant("c_1")
+        self.assertFalse(const.update_leafs_mop(_EmptyCandidate()))
+
+    def test_short_circuit_via_other2_fallback(self):
+        """Short-circuit fires regardless of which candidate is provided."""
+        const = p_ast.AstConstant("ONE", expected_value=1)
+        self.assertTrue(
+            const.update_leafs_mop(_EmptyCandidate(), _EmptyCandidate())
+        )


### PR DESCRIPTION
## Summary
- `AstConstant.update_leafs_mop` returned `False` whenever the constant's name was missing from the candidate's `leafs_by_name` — **even when `expected_value` was already set** at construction time. This silently broke any REPLACEMENT that referenced a numeric constant not present in PATTERN (e.g. `Mul_FactorRule_2` with `NEG_TWO * (x & y)`), because the early-return aborted `IDAPatternAdapter.get_replacement` before `_materialize_replacement_constants` (which can synthesise a `mop_t` from `expected_value`) ever ran.
- Short-circuit to `True` when `expected_value is not None` and no candidate binding exists. Pattern-bound constants without `expected_value` still return `False`, preserving previous behaviour.
- Adds 4 regression tests as a `unittest.TestCase` class in `tests/system/runtime/expr/test_ast_update_leafs_mop.py`. Verified manually inside IDA via the d810 testbed UI (all 4 PASS).

## Test plan
- [x] Open IDA 9.x with any DB, run d810 test browser → `TestAstConstantUpdateLeafsMop` (4 tests) — all PASS
- [x] Reproduced the original bug pre-fix: `Mul_FactorRule_2` REPLACEMENT returned `None` from `get_replacement` → rule silently inert in live microcode
- [x] Post-fix: rules with literal constants in REPLACEMENT now fire correctly