### PR TITLE
fix(tests): quiet module-load errors in d810 in-IDA test browser

### DIFF
--- a/tests/system/runtime/optimizers/microcode/flow/flattening/test_unflattener_fake_jump.py
+++ b/tests/system/runtime/optimizers/microcode/flow/flattening/test_unflattener_fake_jump.py
@@ -21,7 +21,25 @@ import platform
 
 import pytest
 
-import idapro
+# Quiet idapro import: this file's tests are all pytest-style (no
+# unittest.TestCase), so unittest.defaultTestLoader.discover ignores them
+# and only needs the module to import cleanly. Raising at module load
+# creates ModuleSkipped/_FailedTest placeholders that d810's in-IDA test
+# browser mis-treats as importable modules. A silent try/except keeps the
+# module importable; pytest-level skips below guard execution.
+try:
+    import idapro
+except ImportError:
+    idapro = None
+
+# Skip the whole file under pytest when idapro is unavailable. This module's
+# fixtures call idapro.open_database, so without it every test would AttributeError
+# at runtime. unittest ignores pytestmark; this only affects pytest collection.
+pytestmark = pytest.mark.skipif(
+    idapro is None,
+    reason="idapro (idalib) not available — set IDADIR to your IDA 9.0+ install",
+)
+
 import ida_hexrays
 import idaapi
 import idc

--- a/tests/system/runtime/test_capture_integration.py
+++ b/tests/system/runtime/test_capture_integration.py
@@ -9,7 +9,7 @@ import tempfile
 
 import pytest
 
-from tests.system.runtime.test_capture import (
+from .test_capture import (
     TestResultCapture,
     TestResultQuery,
     init_database,

--- a/tests/system/runtime/test_cython_benchmark.py
+++ b/tests/system/runtime/test_cython_benchmark.py
@@ -14,7 +14,7 @@ import pytest
 
 import ida_hexrays
 
-from tests.system.runtime.bench_utils import BenchResult, timed_run
+from .bench_utils import BenchResult, timed_run
 
 # Import both implementations directly for comparison
 try:

--- a/tests/system/runtime/test_pxd_equivalence.py
+++ b/tests/system/runtime/test_pxd_equivalence.py
@@ -5,9 +5,20 @@ to verify the structures are bound identically.
 """
 import pytest
 
-pytest.importorskip("idapro")
+# Quiet idapro import: this file's tests are all pytest-style functions (no
+# unittest.TestCase classes), so unittest.defaultTestLoader.discover ignores
+# them. The only thing it needs from this module is a clean import. Raising
+# pytest.importorskip / unittest.SkipTest at module load creates dynamic
+# placeholder classes (``ModuleSkipped`` / ``_FailedTest``) that d810's
+# in-IDA test browser then mis-identifies as importable modules and tries to
+# re-load — failing with AttributeError noise. A plain try/except keeps the
+# module importable; the @pytest.mark.xfail(run=False) on the test body
+# already guards execution when idapro is unavailable.
+try:
+    import idapro
+except ImportError:
+    idapro = None
 
-import idapro
 import ida_hexrays
 
 


### PR DESCRIPTION
## Summary
When `src/d810/ui/testbed.py` uses `unittest.defaultTestLoader.discover`, four files in `tests/system/runtime/` raised module-load exceptions that surfaced as phantom test entries (`unittest.loader._FailedTest.runtime`, `_FailedTest.ModuleSkipped`) the browser then errored on with `AttributeError`:

1. **`test_pxd_equivalence.py`** — `pytest.importorskip(idapro)` raises `_pytest.outcomes.Skipped`, which unittest treats as ImportError.
2. **`test_unflattener_fake_jump.py`** — bare `import idapro` fails without `IDADIR`.
3. **`test_cython_benchmark.py`** — `from tests.system.runtime.bench_utils import ...` needs `tests` on sys.path (pytest conftest arranges; unittest doesn't).
4. **`test_capture_integration.py`** — same absolute-import issue as case (3).

## Fixes
- (1) and (2): replace noisy module-load skip with silent `try/except ImportError: idapro = None`. Files have only pytest-style tests (no `unittest.TestCase`), so `unittest.discover` ignores them once import succeeds. Pytest behaviour preserved via existing `xfail(run=False)` on (1) and new `pytestmark = pytest.mark.skipif(idapro is None, ...)` on (2).
- (3) and (4): switch to relative imports (`from .bench_utils ...`, `from .test_capture ...`). Works under both pytest (PROJECT_ROOT on sys.path) and `unittest.discover` (package = top-level dir).

## Test plan
- [x] **d810 test browser**: phantom `_FailedTest.runtime` and `ModuleSkipped` entries gone after Reload; remaining tests run normally
- [x] **pytest with `IDADIR` set**: 15 tests collected from the two `idapro`-dependent files (unchanged from pre-fix)
- [x] **pytest without `IDADIR`**: `tests/system/conftest.py:71` module-level `pytest.skip` continues to short-circuit the whole subtree (untouched by this PR)