### PR TITLE
feat(cfg): add make_nway_block_goto for jtbl/switch dispatcher folding

### DIFF
--- a/src/d810/hexrays/cfg_utils.py
+++ b/src/d810/hexrays/cfg_utils.py
@@ -604,6 +604,62 @@ def make_2way_block_goto(blk: ida_hexrays.mblock_t, blk_successor_serial: int, v
         raise e
 
 
+def make_nway_block_goto(blk: ida_hexrays.mblock_t, blk_successor_serial: int, verify: bool = True) -> bool:
+    """Convert an N-way block (m_jtbl, switch dispatcher) to a 1-way goto.
+
+    Generalisation of :func:`make_2way_block_goto`: handles any
+    ``nsucc() >= 2``. Used to fold an m_jtbl/switch dispatcher whose case
+    targets have been fully resolved (typically via emulation in
+    UnflattenerSwitchCase), leaving only one live edge that should be
+    followed unconditionally.
+
+    Why a separate helper rather than reusing make_2way_block_goto:
+    the 2-way version assumes exactly two successors and only removes
+    one of them, leaving stale edges and a corrupt CFG when applied to
+    an N-way (jtbl) dispatcher with N>2. This helper drops *all* prior
+    successors uniformly.
+    """
+    if blk.nsucc() < 2:
+        return False
+    mba = blk.mba
+    previous_blk_successor_serials = [x for x in blk.succset]
+    previous_blk_successors = [
+        mba.get_mblock(x) for x in previous_blk_successor_serials
+    ]
+
+    insert_goto_instruction(blk, blk_successor_serial, nop_previous_instruction=True)
+
+    blk.type = ida_hexrays.BLT_1WAY
+    blk.flags |= ida_hexrays.MBL_GOTO
+
+    for prev_serial in previous_blk_successor_serials:
+        blk.succset._del(prev_serial)
+    blk.succset.push_back(blk_successor_serial)
+    blk.mark_lists_dirty()
+
+    for prev_blk in previous_blk_successors:
+        prev_blk.predset._del(blk.serial)
+        if prev_blk.serial != mba.qty - 1:
+            prev_blk.mark_lists_dirty()
+
+    new_blk_successor = blk.mba.get_mblock(blk_successor_serial)
+    new_blk_successor.predset.push_back(blk.serial)
+    if new_blk_successor.serial != mba.qty - 1:
+        new_blk_successor.mark_lists_dirty()
+
+    mba.mark_chains_dirty()
+    if not verify:
+        return True
+    try:
+        mba.verify(True)
+        return True
+    except RuntimeError as e:
+        helper_logger.error("Error in make_nway_block_goto: {0}".format(e))
+        log_block_info(blk, helper_logger.error)
+        log_block_info(new_blk_successor, helper_logger.error)
+        raise e
+
+
 def create_block(
     blk: ida_hexrays.mblock_t, blk_ins: list[ida_hexrays.minsn_t], is_0_way: bool = False, verify: bool = True
 ) -> ida_hexrays.mblock_t:

--- a/src/d810/hexrays/deferred_modifier.py
+++ b/src/d810/hexrays/deferred_modifier.py
@@ -207,6 +207,7 @@ from d810.hexrays.cfg_utils import (
     insert_nop_blk,
     log_block_info,
     make_2way_block_goto,
+    make_nway_block_goto,
     mba_deep_cleaning,
     safe_verify,
     snapshot_block_for_capture,
@@ -1332,8 +1333,13 @@ class DeferredGraphModifier:
         return change_2way_block_conditional_successor(blk, new_target, verify=False)
 
     def _apply_convert_to_goto(self, blk: ida_hexrays.mblock_t, goto_target: int) -> bool:
-        """Convert a 2-way block to a 1-way goto."""
-        return make_2way_block_goto(blk, goto_target, verify=False)
+        """Convert a 2-way or N-way block to a 1-way goto."""
+        nsucc = blk.nsucc()
+        if nsucc == 2:
+            return make_2way_block_goto(blk, goto_target, verify=False)
+        if nsucc > 2:
+            return make_nway_block_goto(blk, goto_target, verify=False)
+        return False
 
     def _apply_insn_remove(self, blk: ida_hexrays.mblock_t, insn_ea: int) -> bool:
         """Remove an instruction by its EA."""
@@ -1847,8 +1853,13 @@ class ImmediateGraphModifier:
         return change_2way_block_conditional_successor(blk, new_target, verify=False)
 
     def _apply_convert_to_goto(self, blk: ida_hexrays.mblock_t, goto_target: int) -> bool:
-        """Convert a 2-way block to a 1-way goto."""
-        return make_2way_block_goto(blk, goto_target, verify=False)
+        """Convert a 2-way or N-way block to a 1-way goto."""
+        nsucc = blk.nsucc()
+        if nsucc == 2:
+            return make_2way_block_goto(blk, goto_target, verify=False)
+        if nsucc > 2:
+            return make_nway_block_goto(blk, goto_target, verify=False)
+        return False
 
     def _apply_insn_remove(self, blk: ida_hexrays.mblock_t, insn_ea: int) -> bool:
         """Remove an instruction by its EA."""

--- a/tests/system/runtime/optimizers_unit/test_cfg_utils_regressions.py
+++ b/tests/system/runtime/optimizers_unit/test_cfg_utils_regressions.py
@@ -298,6 +298,79 @@ def test_create_block_0way_clears_goto_and_edges(monkeypatch):
     assert mba.marked_dirty == 1
 
 
+def test_make_nway_block_goto_folds_three_way_to_single_edge(monkeypatch):
+    """Folding a 3-way dispatcher (e.g. m_jtbl with 3 case targets) to a
+    1-way goto must drop ALL prior successors uniformly and rewire only
+    the chosen target's predset."""
+    from d810.hexrays import cfg_utils
+
+    mba = _FakeMBA(qty=10)
+    # 3-way dispatcher block (jtbl-style) with 3 case targets
+    dispatcher = _FakeBlock(2, mba, succs=[5, 6, 7], preds=[1])
+    case_a = _FakeBlock(5, mba, succs=[], preds=[2])
+    case_b = _FakeBlock(6, mba, succs=[], preds=[2])
+    case_c = _FakeBlock(7, mba, succs=[], preds=[2])
+
+    # Stub insert_goto_instruction (the test only cares about CFG bookkeeping)
+    monkeypatch.setattr(
+        cfg_utils,
+        "insert_goto_instruction",
+        lambda *_a, **_k: None,
+    )
+
+    result = cfg_utils.make_nway_block_goto(dispatcher, 6, verify=False)
+
+    assert result is True
+    assert dispatcher.type == cfg_utils.ida_hexrays.BLT_1WAY
+    assert (dispatcher.flags & cfg_utils.ida_hexrays.MBL_GOTO) != 0
+    # All prior successors removed, only the new target remains
+    assert list(dispatcher.succset) == [6]
+    # Every prior case had us in its predset; only case_b stays connected
+    assert 2 not in case_a.predset
+    assert list(case_b.predset).count(2) == 1
+    assert 2 not in case_c.predset
+
+
+def test_make_nway_block_goto_refuses_one_way_block(monkeypatch):
+    """A block with nsucc()<2 cannot be folded -- helper must return False."""
+    from d810.hexrays import cfg_utils
+
+    mba = _FakeMBA(qty=4)
+    blk = _FakeBlock(1, mba, succs=[2])
+    _FakeBlock(2, mba, succs=[])
+
+    monkeypatch.setattr(
+        cfg_utils,
+        "insert_goto_instruction",
+        lambda *_a, **_k: pytest.fail("insert_goto_instruction should not be called"),
+    )
+
+    assert cfg_utils.make_nway_block_goto(blk, 2, verify=False) is False
+
+
+def test_make_nway_block_goto_handles_two_way_for_completeness(monkeypatch):
+    """make_nway_block_goto must also handle nsucc()==2 (subsumes 2way case).
+    Distinct from make_2way_block_goto behavior: this one drops both
+    successors uniformly rather than special-casing them."""
+    from d810.hexrays import cfg_utils
+
+    mba = _FakeMBA(qty=5)
+    blk = _FakeBlock(1, mba, succs=[2, 3], preds=[0])
+    succ_a = _FakeBlock(2, mba, succs=[], preds=[1])
+    succ_b = _FakeBlock(3, mba, succs=[], preds=[1])
+
+    monkeypatch.setattr(
+        cfg_utils,
+        "insert_goto_instruction",
+        lambda *_a, **_k: None,
+    )
+
+    assert cfg_utils.make_nway_block_goto(blk, 3, verify=False) is True
+    assert list(blk.succset) == [3]
+    assert 1 not in succ_a.predset
+    assert list(succ_b.predset).count(1) == 1
+
+
 def test_safe_verify_persists_failure_artifact(tmp_path, monkeypatch):
     """safe_verify should emit a JSON artifact with focused block capture."""
     from d810.hexrays import cfg_utils


### PR DESCRIPTION
## Summary

`make_2way_block_goto` only handles `nsucc() == 2`. When an N-way dispatcher (m_jtbl or compiler-lowered `switch`) has its case targets fully resolved -- e.g. by emulating dispatcher state in `UnflattenerSwitchCase` -- we want to collapse the whole dispatcher to a single goto to the resolved target. Using `make_2way_block_goto` on such a block leaves stale successor edges and `mba.verify(True)` fails on the next maturity.

## What was missing

For an N-way dispatcher with `nsucc() == k > 2`:

- `make_2way_block_goto` only drops one of the original successors from `blk.succset` and only fixes one `predset`; the other `k - 2` edges stay
- The block is retyped to `BLT_1WAY` but still has `k - 1` ghost successors, so the next CFG verification trips

## What changed

Adds `make_nway_block_goto(blk, target_serial, verify=True)`:

- Refuses blocks with `nsucc() < 2`
- Drops ALL prior successors uniformly (both `blk.succset` and every former target's `predset`)
- Inserts the goto instruction, retypes the block to `BLT_1WAY`, marks `mark_lists_dirty` / `mark_chains_dirty`
- `mba.verify(True)` unless `verify=False`

Wires `DeferredModifier._apply_convert_to_goto` (two sites that share the implementation) to delegate to `make_nway_block_goto` when `nsucc() > 2`, keeping the existing `make_2way_block_goto` path for plain conditional jumps.

## Test plan

Three new tests in `test_cfg_utils_regressions.py` using the existing `_FakeMBA` / `_FakeBlock` mock infrastructure:

- `test_make_nway_block_goto_folds_three_way_to_single_edge` -- 3-way dispatcher folds to one edge, prior `succset` and the dropped targets' `predset` are cleared
- `test_make_nway_block_goto_refuses_one_way_block` -- `nsucc() < 2` returns False without touching the CFG
- `test_make_nway_block_goto_handles_two_way_for_completeness` -- the helper also subsumes the `nsucc() == 2` case so callers can dispatch uniformly

Run:

```
pytest tests/system/runtime/optimizers_unit/test_cfg_utils_regressions.py
# 12 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)