### PR TITLE
fix(p_ast): reset AstConstant.expected_value to constructor default

### DIFF
--- a/src/d810/expr/p_ast.py
+++ b/src/d810/expr/p_ast.py
@@ -865,6 +865,13 @@ class AstLeaf(AstBase):
             new_leaf.expected_value = self.expected_value
         if hasattr(self, "expected_size"):
             new_leaf.expected_size = self.expected_size
+        # Propagate the "initial" snapshot so the clone's reset_mops() also
+        # restores correctly. Without this, cloned candidates lose their
+        # initial state and reset becomes a no-op.
+        if hasattr(self, "_initial_expected_value"):
+            new_leaf._initial_expected_value = self._initial_expected_value
+        if hasattr(self, "_initial_expected_size"):
+            new_leaf._initial_expected_size = self._initial_expected_size
 
         # Initialize transient state
         new_leaf.z3_var = None
@@ -1001,6 +1008,11 @@ class AstLeaf(AstBase):
         self.z3_var = None
         self.z3_var_name = NOT_GIVEN
         self.mop = None
+        # Clear dynamic .value set by update_leafs_mop (line ~986). Without this,
+        # a Const placeholder whose first match bound it to e.g. 8 keeps that
+        # value for every subsequent match and silently rejects other constants.
+        if "value" in self.__dict__:
+            del self.__dict__["value"]
 
     def _copy_mops_from_ast(self, other, read_only: bool = False):
         if other.mop is None:
@@ -1096,6 +1108,17 @@ class AstConstant(AstLeaf):
         super().__init__(name)
         self.expected_value = expected_value
         self.expected_size = expected_size
+        # Remember constructor-provided values so reset_mops() can restore them
+        # after a successful match. _copy_mops_from_ast mutates expected_value
+        # for free Const placeholders (line ~1138); without restoring on reset,
+        # the pattern stays bound to the first match's literal forever.
+        self._initial_expected_value = expected_value
+        self._initial_expected_size = expected_size
+
+    def reset_mops(self):
+        super().reset_mops()
+        self.expected_value = self._initial_expected_value
+        self.expected_size = self._initial_expected_size
 
     @property
     def value(self):

--- a/tests/system/runtime/expr/test_ast_constant_reset.py
+++ b/tests/system/runtime/expr/test_ast_constant_reset.py
@@ -1,0 +1,111 @@
+"""Regression tests for AstConstant.reset_mops restoring initial state.
+
+Before the fix, a free placeholder ``Const("c")`` (no initial expected_value)
+that was bound to a concrete value by ``_copy_mops_from_ast`` during a
+successful match retained that value forever. ``reset_mops()`` only cleared
+``self.mop``; ``expected_value`` was left mutated. The next match attempt
+with a different constant in the same slot was silently rejected at the
+equality check in ``_copy_mops_from_ast``.
+
+These tests exercise the contract: after ``reset_mops()``, every
+``AstConstant`` must look exactly like it did right after ``__init__``.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from d810.expr import p_ast
+
+
+class TestAstConstantResetMops(unittest.TestCase):
+    """reset_mops() must restore constructor-provided state."""
+
+    def test_free_const_reverts_to_none(self):
+        """Const("c_1") with no initial: simulated match sets expected_value,
+        reset_mops() must clear it back to None."""
+        c = p_ast.AstConstant("c_1")
+        self.assertIsNone(c.expected_value)
+        self.assertIsNone(c.expected_size)
+
+        # Simulate _copy_mops_from_ast binding the placeholder
+        c.expected_value = 8
+        c.expected_size = 4
+        self.assertEqual(c.expected_value, 8)
+
+        c.reset_mops()
+        self.assertIsNone(
+            c.expected_value,
+            "reset_mops should restore expected_value to its constructor value",
+        )
+        self.assertIsNone(c.expected_size)
+
+    def test_initial_const_is_preserved_across_reset(self):
+        """Const("TWO", 2) was given an initial value; reset_mops() must NOT
+        clobber it -- only restore it after any mutation."""
+        t = p_ast.AstConstant("TWO", 2, 8)
+        self.assertEqual(t.expected_value, 2)
+        self.assertEqual(t.expected_size, 8)
+
+        # Even a no-op reset should leave the initial intact
+        t.reset_mops()
+        self.assertEqual(t.expected_value, 2)
+        self.assertEqual(t.expected_size, 8)
+
+        # Mutate then reset — initial must come back
+        t.expected_value = 99
+        t.expected_size = 1
+        t.reset_mops()
+        self.assertEqual(t.expected_value, 2)
+        self.assertEqual(t.expected_size, 8)
+
+    def test_match_unbind_match_cycle(self):
+        """The core scenario: bind to one literal, reset, bind to a different
+        literal. Without the fix, the second binding's equality check would
+        return False because expected_value still held the first literal."""
+        c = p_ast.AstConstant("c_1")
+
+        # First match site: input constant = 8
+        c.expected_value = 8
+        self.assertEqual(c.expected_value, 8)
+
+        # Pattern is reset before the next match attempt
+        c.reset_mops()
+
+        # Second match site: input constant = 1. Without the fix, expected_value
+        # is still 8 here and the new binding's equality check rejects it.
+        # With the fix, expected_value is back to None and binding proceeds.
+        self.assertIsNone(c.expected_value)
+        c.expected_value = 1
+        self.assertEqual(c.expected_value, 1)
+
+    def test_clone_carries_initial(self):
+        """clone() must propagate _initial_* so the clone's reset_mops() also
+        restores correctly. Without this, candidates produced by ast_generator
+        (which clones) would be permanent: reset would set expected_value to
+        None even if the original was created with an initial like TWO."""
+        original = p_ast.AstConstant("TWO", 2)
+        clone = original.clone()
+        self.assertEqual(clone.expected_value, 2)
+
+        # Mutate the clone (simulate a match binding it)
+        clone.expected_value = 99
+        clone.reset_mops()
+        self.assertEqual(
+            clone.expected_value,
+            2,
+            "clone() must propagate _initial_expected_value for reset to work",
+        )
+
+    def test_clone_of_free_const_resets_to_none(self):
+        """A free clone (Const without initial) must reset to None, not to
+        whatever value it carried at clone time."""
+        original = p_ast.AstConstant("c_2")
+        clone = original.clone()
+        clone.expected_value = 16  # bound during a match
+        clone.reset_mops()
+        self.assertIsNone(clone.expected_value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`AstConstant._copy_mops_from_ast` (p_ast.py ~line 1135) mutates `self.expected_value` (and `self.expected_size`) whenever it binds a free `Const("c")` placeholder to a concrete input constant during a successful match. The existing `reset_mops()` only clears `self.mop` / `self.z3_var` / `self.z3_var_name` — it does **not** restore `expected_value`.

After the first successful match binds a free placeholder to e.g. `8`, the pattern keeps `expected_value=8` for all subsequent match attempts. The equality check on line ~1146 (`return self.expected_value == other_value`) then silently rejects every later input whose constant in that slot differs from `8`.

### Visible symptom

A rule like:

```python
class Sub_OllvmConstSplit_1(VerifiableRule):
    c_1 = Const("c_1")
    c_2 = Const("c_2")
    PATTERN = ((TWO * x) | c_2) - (x ^ c_1)
    REPLACEMENT = x + c_1
    CONSTRAINTS = [c_2 == TWO * c_1]
```

fires on the first matching site (e.g. `c_1=8, c_2=16`), then silently skips structurally identical sites with different constants in those slots (e.g. `c_1=1, c_2=2`). Affects any rule with two or more free `Const` placeholders — i.e. most non-trivial families.

The bug is independent from the existing opt-in non-mutating path (`D810_NOMUT_MATCHING=1`). It applies to the default (mutating) pattern matching path.

## Fix

Three small changes in `src/d810/expr/p_ast.py`:

1. **`AstConstant.__init__`** — remember `_initial_expected_value` and `_initial_expected_size` so reset can restore them.
2. **New `AstConstant.reset_mops()` override** — chains to `super().reset_mops()`, then restores `expected_value` / `expected_size` from the saved initials.
3. **`AstLeaf.clone()`** — propagate `_initial_*` to clones, otherwise candidates produced by `ast_generator` lose their initial snapshot and reset becomes a no-op.

A defensive `del self.__dict__[\"value\"]` was also added to `AstLeaf.reset_mops` to clear any dynamic `self.value` set by `update_leafs_mop` on inferred-value branches (`AstLeaf.value` is normally a computed property over `self.mop`, but the `update_leafs_mop` path sets it as an instance attribute when the source leaf has no `mop` but does carry a `value`).

Total: ~25 lines.

## Tests

Added `tests/system/runtime/expr/test_ast_constant_reset.py` with 5 cases:

- free `Const(\"c\")` reverts to `None` after `reset_mops()`
- initialised `Const(\"TWO\", 2)` preserves its initial across `reset_mops()`
- match → reset → match cycle with two different literals succeeds for both
- `clone()` propagates `_initial_*` so cloned patterns also reset correctly
- clone of a free `Const` resets to `None`

These live under `tests/system/runtime/` because importing `p_ast` requires `ida_hexrays`, per the existing unit-test rule (no IDA mocks in `tests/unit/`).

## Notes

- Confirmed empirically on an OLLVM-obfuscated iOS arm64 function: applying this fix unlocked four previously silently-skipped rules (`Sub_OllvmConstSplit_1`, `Sub_OllvmOpaqueRule_1`, `Sub_OllvmXorSubFold_1`, `Add_OllvmXorMinusFold_1`) and several new fold sites in a single function.
- The Cython mirror (`src/d810/speedups/expr/c_ast.pyx` — `cdef class AstConstant`) needs the analogous change for `CythonMode=ON` users. Not included here because I cannot rebuild/verify the Cython path locally; happy to follow up in a separate PR if a maintainer or Cython-mode user can validate.
- Diagnostic discovery details:
  - Walked `pattern_candidates` via `py_eval` on a live `PatternOptimizer` instance and saw `AstConstant(name='c_1', expected_value=8, value=8, ...)` for what was originally declared as `Const(\"c_1\")` with no initial value — i.e. the mutation persisted across decompile passes.
  - Verified with `D810_NOMUT_MATCHING=1` that `pattern_candidates` stay clean (no leaked `expected_value`), but the nomut path itself produced 0 matches for the same rule (separate, unrelated issue worth its own investigation).

Marking as draft to allow review and discussion before merging.