### PR TITLE
fix(mop_snapshot): use make_gvar instead of typo'd make_global (#44)

### DIFF
--- a/src/d810/hexrays/mop_snapshot.py
+++ b/src/d810/hexrays/mop_snapshot.py
@@ -259,7 +259,11 @@ if not _CYTHON_AVAILABLE:
                         "to_mop: Cannot reconstruct mop_S without mba_t, returning empty mop"
                     )
             elif self.t == ida_hexrays.mop_v and self.gaddr is not None:
-                m.make_global(self.gaddr, self.size)
+                # mop_t exposes ``make_gvar(addr)``, not ``make_global``;
+                # the old name was a typo. Size must be assigned separately.
+                # See issue #44.
+                m.make_gvar(int(self.gaddr))
+                m.size = int(self.size) if self.size is not None else 0
             elif self.t == ida_hexrays.mop_l and self.lvar_idx is not None:
                 # Local variable: requires lvar_t, which we can't fully reconstruct
                 # without the parent mba_t. Log warning and return empty mop.

--- a/tests/system/runtime/hexrays/test_mop_snapshot.py
+++ b/tests/system/runtime/hexrays/test_mop_snapshot.py
@@ -98,3 +98,55 @@ class TestMopSnapshotProperties:
         import ida_hexrays
         snap = MopSnapshot(t=ida_hexrays.mop_n, size=4, value=42)
         assert snap.is_register is False
+
+
+@pytest.mark.ida_required
+class TestMopSnapshotToMop:
+    """Test that to_mop() reconstructs a real mop_t from a snapshot.
+
+    The mop_v branch in particular must work on Hex-Rays 9.x SDKs where
+    ``mop_t.make_global`` is not exposed (issue #44). Other branches are
+    sanity-checked to guard against the same class of SDK drift.
+    """
+
+    def test_to_mop_global_reconstructs_mop_v(self):
+        """mop_v branch — guards against missing mop_t.make_global (#44)."""
+        import ida_hexrays
+        snap = MopSnapshot(
+            t=ida_hexrays.mop_v, size=8, gaddr=0x140001000
+        )
+        m = snap.to_mop()
+        assert isinstance(m, ida_hexrays.mop_t)
+        assert m.t == ida_hexrays.mop_v
+        assert m.g == 0x140001000
+        assert m.size == 8
+
+    def test_to_mop_number_reconstructs_mop_n(self):
+        import ida_hexrays
+        snap = MopSnapshot(t=ida_hexrays.mop_n, size=4, value=0xDEADBEEF)
+        m = snap.to_mop()
+        assert m.t == ida_hexrays.mop_n
+        assert m.size == 4
+        assert m.nnn.value == 0xDEADBEEF
+
+    def test_to_mop_register_reconstructs_mop_r(self):
+        import ida_hexrays
+        snap = MopSnapshot(t=ida_hexrays.mop_r, size=8, reg=16)
+        m = snap.to_mop()
+        assert m.t == ida_hexrays.mop_r
+        assert m.size == 8
+        assert m.r == 16
+
+    def test_to_mop_helper_reconstructs_mop_h(self):
+        import ida_hexrays
+        snap = MopSnapshot(t=ida_hexrays.mop_h, size=0, helper_name="memcpy")
+        m = snap.to_mop()
+        assert m.t == ida_hexrays.mop_h
+        assert m.helper == "memcpy"
+
+    def test_to_mop_blkref_reconstructs_mop_b(self):
+        import ida_hexrays
+        snap = MopSnapshot(t=ida_hexrays.mop_b, size=0, block_num=7)
+        m = snap.to_mop()
+        assert m.t == ida_hexrays.mop_b
+        assert m.b == 7


### PR DESCRIPTION
## Summary

`MopSnapshot.to_mop()` calls `m.make_global(self.gaddr, self.size)` on the `mop_v` branch, but `mop_t` exposes `make_gvar(addr)` — `make_global` was a long-standing typo in the codebase and never matched any Hex-Rays Python API (confirmed against [the official IDAPython docs](https://python.docs.hex-rays.com/classida__hexrays_1_1mop__t.html) and `dir(mop_t())` on IDA 9.3, which yields `make_blkref / make_first_half / make_fpnum / make_gvar / make_helper / make_high_half / make_insn / make_low_half / make_number / make_reg / make_reg_pair / make_second_half / make_stkvar` — no `make_global`).

On every IDA version the resulting `AttributeError` aborts the rewrite mid-decompile; downstream this surfaces as `mba.verify()` returning `INTERR: 50874` from `safe_verify`, eventually putting the optimizer into a tight loop on the same maturity.

`make_gvar` takes only the address — size has to be assigned separately:

```python
elif self.t == ida_hexrays.mop_v and self.gaddr is not None:
    m.make_gvar(int(self.gaddr))
    m.size = int(self.size) if self.size is not None else 0
```

## Test plan

Adds a `TestMopSnapshotToMop` class in `tests/system/runtime/hexrays/test_mop_snapshot.py` covering:

- the `mop_v` branch (the actual #44 regression)
- the other reconstruction branches that share the same SDK-naming risk surface — `mop_n`, `mop_r`, `mop_h`, `mop_b`

Verified locally inside IDA Pro 9.3 (Hex-Rays 9.3, Python 3.11): all five assertions pass, e.g. `to_mop(mop_v, size=8, gaddr=0x140001000)` returns a `mop_t` with `t=mop_v`, `g=0x140001000`, `size=8`.

Fixes #44