### PR TITLE
fix(plugin): defer hexx64 decompiler load off plugin init (INTERR 50735, #41/#61)

### DIFF
--- a/src/d810/manager.py
+++ b/src/d810/manager.py
@@ -715,6 +715,12 @@ class D810State(metaclass=SingletonMeta):
         return self.current_project
 
     def start_d810(self):
+        # Deferred decompiler load: ensure Hex-Rays is loaded before installing
+        # microcode hooks (moved off plugin init / IDB open).
+        from d810ng import ensure_hexrays
+        if not ensure_hexrays(force_load=True):
+            logger.error("Cannot start D-810: Hex-Rays decompiler is not available")
+            return
         self.manager.configure_instruction_optimizer(
             [rule for rule in self.current_ins_rules],
             generate_z3_code=self.d810_config.get("generate_z3_code"),

--- a/src/d810/ui/context_menu.py
+++ b/src/d810/ui/context_menu.py
@@ -188,11 +188,18 @@ class D810ContextMenu:
                 action_count += 1
             else:
                 logger.warning("Failed to register action %s", action_cls.ACTION_ID)
-        # Install the pseudocode popup hook
-        self._popup_hook = D810PopupHook(self)
-        self._popup_hook.hook()
+        # Install the pseudocode popup hook (Hexrays_Hooks -> needs decompiler).
+        # Best-effort so a not-yet-loaded decompiler (deferred load) does not
+        # break action registration.
+        try:
+            self._popup_hook = D810PopupHook(self)
+            self._popup_hook.hook()
+        except Exception:
+            logger.warning(
+                "D810 pseudocode popup hook not installed (decompiler not ready)"
+            )
 
-        # Install the disassembly popup hook
+        # Install the disassembly popup hook (UI_Hooks; no decompiler needed).
         self._disasm_popup_hook = D810DisasmPopupHook(self)
         self._disasm_popup_hook.hook()
 

--- a/src/d810ng.py
+++ b/src/d810ng.py
@@ -10,24 +10,38 @@ from d810.core.typing import override
 D810_VERSION = d810.__version__
 
 
-def init_hexrays() -> bool:
-    ALL_DECOMPILERS = {
-        idaapi.PLFM_386: "hexx64",
-        idaapi.PLFM_ARM: "hexarm",
-        idaapi.PLFM_PPC: "hexppc",
-        idaapi.PLFM_MIPS: "hexmips",
-        idaapi.PLFM_RISCV: "hexrv",
-    }
-    cpu = idaapi.ph.id
-    decompiler = ALL_DECOMPILERS.get(cpu, None)
+# Processor id -> Hex-Rays decompiler plugin name.
+ALL_DECOMPILERS = {
+    idaapi.PLFM_386: "hexx64",
+    idaapi.PLFM_ARM: "hexarm",
+    idaapi.PLFM_PPC: "hexppc",
+    idaapi.PLFM_MIPS: "hexmips",
+    idaapi.PLFM_RISCV: "hexrv",
+}
+
+
+def decompiler_for_current_arch():
+    """Return the Hex-Rays decompiler plugin name for the current processor,
+    or None if this architecture has no known decompiler."""
+    return ALL_DECOMPILERS.get(idaapi.ph.id, None)
+
+
+def ensure_hexrays(force_load: bool = False) -> bool:
+    """Ensure the Hex-Rays decompiler is initialized.
+
+    With force_load=False an already-available decompiler is initialized but the
+    decompiler plugin is never eagerly load_plugin-ed, so plugin init() does not
+    force hexx64 to load during IDB open. Callers that need the decompiler
+    (start_d810) pass force_load=True to load it on demand.
+    """
+    decompiler = decompiler_for_current_arch()
     if not decompiler:
-        print("No known decompilers for architecture with ID: %d" % idaapi.ph.id)
         return False
-    if idaapi.load_plugin(decompiler) and idaapi.init_hexrays_plugin():
+    if ida_hexrays.init_hexrays_plugin():
         return True
-    else:
-        print(f"Couldn't load or initialize decompiler: {decompiler}")
-        return False
+    if force_load and idaapi.load_plugin(decompiler) and ida_hexrays.init_hexrays_plugin():
+        return True
+    return False
 
 
 class _UIHooks(idaapi.UI_Hooks):
@@ -69,8 +83,11 @@ class D810Plugin(
 
     @override
     def init(self):
-        if not init_hexrays():
-            print(f"{self.wanted_name} need Hex-Rays decompiler. Skipping")
+        if decompiler_for_current_arch() is None:
+            print(
+                f"{self.wanted_name}: no known Hex-Rays decompiler for this "
+                "architecture. Skipping"
+            )
             return idaapi.PLUGIN_SKIP
 
         kv = ida_kernwin.get_kernel_version().split(".")
@@ -82,9 +99,9 @@ class D810Plugin(
     @override
     def late_init(self):
         super().late_init()
-        if not ida_hexrays.init_hexrays_plugin():
-            print(f"{self.wanted_name} need Hex-Rays decompiler. Unloading...")
-            self.term()
+        # Decompiler load is deferred to start_d810(); do not force-init here.
+        # (The old check called term() then fell through, leaving a
+        # half-torn-down plugin.)
         print(f"{self.wanted_name} initialized (version {D810_VERSION})")
 
     @override


### PR DESCRIPTION
## Summary

Defer the Hex-Rays decompiler force-load off the plugin `init()` / IDB-open path
into `start_d810()`. Opening an IDB no longer eagerly `load_plugin("hexx64")`s the
decompiler during the plugin lifecycle — the decompiler is loaded on demand only
when D-810 is actually started (and best-effort when the GUI popup hook installs).

This targets the load-time `INTERR 50735` reports on IDA 9.3 (#41, #61). That
`INTERR` is a Hex-Rays internal arg size/type check (`mcallinfo_t::verify`); it
fires intermittently on the *first* decompile, and D-810 merely being present
(force-loading the decompiler early) appears to raise the odds rather than
deterministically cause it. Deferring the load removes that early pressure and
also fixes a plugin-lifecycle bug where `late_init()` could call `term()` and then
fall through, leaving a half-torn-down plugin.

## Changes

- `src/d810ng.py` — `init()` only checks the arch has a known decompiler
  (`PLUGIN_SKIP` otherwise); no force-load. `late_init()` no longer force-inits
  the decompiler (removes the term-then-fall-through half-teardown).
- `src/d810/manager.py` — `start_d810()` now ensures the decompiler is loaded +
  initialized (`ensure_hexrays`, `force_load=True`) before installing microcode
  hooks; logs and bails cleanly if unavailable.
- `src/d810/ui/context_menu.py` — install the pseudocode popup hook best-effort
  (try/except) so a not-yet-loaded decompiler cannot break action registration.

## Testing

- DSL + A/B suites green locally.
- Could not reproduce `INTERR 50735` on demand (it is intermittent), so this is
  not claimed as a definitive fix. Reporters on #41 / #61: please pull and re-test,
  and note whether a second F5 succeeds when the first errors.

Refs #41, #61
